### PR TITLE
Fix para uso en python 3

### DIFF
--- a/amigocloud/amigocloud.py
+++ b/amigocloud/amigocloud.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 import os
-import urllib2
+import urllib
 from datetime import datetime
 
 import gevent

--- a/amigocloud/amigocloud.py
+++ b/amigocloud/amigocloud.py
@@ -17,7 +17,7 @@ try:
 except AttributeError:
     pass
 
-BASE_URL = 'https://www.amigocloud.com'
+BASE_URL = 'https:/app.amigocloud.com'
 CHUNK_SIZE = 100000  # 100kB
 MAX_SIZE_SIMPLE_UPLOAD = 8000000  # 8MB
 

--- a/amigocloud/amigocloud.py
+++ b/amigocloud/amigocloud.py
@@ -17,7 +17,7 @@ try:
 except AttributeError:
     pass
 
-BASE_URL = 'https:/app.amigocloud.com'
+BASE_URL = 'https://app.amigocloud.com'
 CHUNK_SIZE = 100000  # 100kB
 MAX_SIZE_SIMPLE_UPLOAD = 8000000  # 8MB
 


### PR DESCRIPTION
Después de mucho revisar por que no era capaz de utilizar la función post() del cliente y si poder hacer los requests por fuera del cliente, me di cuenta de que con el simple cambio en la url, cambiando de "www" a "app" se soluciona aquella parte del problema. No chequee todas las funciones existentes porque no las sé utilizar en este momento, pero la función get y post son las más utilizadas. Por otro lado se cambia una dependencia que posiblemente no se utilice pero se cambia para compatibilidad con python 3.